### PR TITLE
Add php 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-      "php": "^7.1",
+      "php": "^7.1|^8.0",
       "illuminate/support": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
When installing the package on environments using `php 8.0`, the installation fails because it does not meet the minimum requirements.

This PR adds `php ^8.0` to the list of requirements satisfiable.  